### PR TITLE
fix(api): Resolved failure when calling forgot-password api

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ app.use('/api', loginRoutes);
 app.use('/api', registerRoutes);
 app.use('/api', loginFacebookRoutes);
 app.use('/api', loginSocialRoutes);
+app.use('/api', forgetPasswordRoutes);
 
 app.use(verifyJWT); // All routes after this will require JWT verification
 
@@ -42,7 +43,6 @@ app.use('/api', familyRoutes);
 
 // app.use('/api', invitationRoutes);
 app.use('/api', memberRoutes);
-app.use('/api', forgetPasswordRoutes);
 app.use('/api', resetPasswordRoutes);
 app.use('/api', logoutRoutes);
 


### PR DESCRIPTION
# Resolved failure when calling forgot-password API

## One Line Description
Removed JWT authentication requirement from forgot-password API

## Requirements
Fix error when calling /api/forgot-password route from server.

## Test Steps
- On http://localhost:3000/forgot-password in frontend, insert a valid email address in input field and click on "Next".  The page should proceed to the following confirmation page:
![image](https://github.com/user-attachments/assets/748abbb7-9bc1-4800-a36a-e51e54477b1d)

-  On http://localhost:3000/forgot-password in frontend, insert an invalid email address in input field and click on "Next".  The page should throw the following error message:
![image](https://github.com/user-attachments/assets/ab10a3cf-0d5c-492e-9f61-476ba68b05f7)

## Testing Instructions for Postman
- Send the following body to "https://localhost:8000/api/forgot-password" :
{"email":  "<insert a valid email address here>"}

You should receive a successful response for a valid email address: 
![image](https://github.com/user-attachments/assets/2b940263-b3d4-408e-bb87-0003cc83d518)

You should receive a 404 response for a invalid email address: 
![image](https://github.com/user-attachments/assets/4e55c7f3-e1cc-4f6f-8da9-c9bb92020652)

## API Changes (if there are any)
Previously API call was failing because server was expecting "Authorization" header in request from frontend. As discussed with Samah, JWT authentication is not required for this route. Once the route was moved above the "verifyJWT" route, issue was resolved.