### PR TITLE
Fix/45/password reset link lifetime

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -9,7 +9,6 @@ require('dotenv').config({ path: './.env.local' });
 // 1 upper/lower case letter, 1 number, 1 special symbol
 // eslint-disable-next-line max-len
 const { passwordRegExp, emailRegExp } = require('../utils/passwordUtils');
-const { createJWTPasswordReset } = require('../utils/tokenUtils');
 const {
   incrementAttempts,
   resetAttempts,
@@ -84,6 +83,7 @@ const accountActivation = asyncWrapper(async (req, res) => {
   const tokenStatus = await verificationTokenService.verifyToken(
     user._id,
     emailVerificationToken,
+    'email',
   );
 
   if (!tokenStatus.valid) {
@@ -298,34 +298,40 @@ const requestResetPassword = asyncWrapper(async (req, res) => {
       .status(StatusCodes.NOT_FOUND)
       .json({ error: 'No user found with this email address' });
   }
-  const passwordResetVerificationToken = await createJWTPasswordReset({
-    email,
-  });
+  const passwordResetVerificationToken =
+    await verificationTokenService.createPasswordToken(user._id, email);
   await emailService.sendResetPasswordEmail(
     email,
     passwordResetVerificationToken,
   );
-
   return res.status(StatusCodes.OK).json({
     message: `Reset password link sent to ${email}`,
   });
 });
 
 const resetPasswordActivation = asyncWrapper(async (req, res) => {
-  const { email, resetPasswordToken } = req.params;
-  const token = await userService.validateUserAndToken(
-    email,
-    resetPasswordToken,
-  );
-  if (token.valid) {
-    return res
-      .status(StatusCodes.CREATED)
-      .json({ status: StatusCodes.CREATED });
+  const { resetPasswordToken, email } = req.params;
+  const user = await userService.findUser(email);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).json({
+      status: StatusCodes.UNAUTHORIZED,
+      message: 'User does not exist',
+    });
   }
-  return res.status(StatusCodes.UNAUTHORIZED).json({
-    status: StatusCodes.UNAUTHORIZED,
-    message: 'User does not exist',
-  });
+
+  // Validate if token has been blacklisted or has expired
+  const token = await verificationTokenService.verifyToken(
+    user._id,
+    resetPasswordToken,
+    'password',
+  );
+  if (!token.valid) {
+    return res
+      .status(StatusCodes.UNAUTHORIZED)
+      .json({ msg: 'Token has expired or is no longer valid.' });
+  }
+
+  return res.status(StatusCodes.CREATED).json({ status: StatusCodes.CREATED });
 });
 
 const resetPasswordUpdates = asyncWrapper(async (req, res) => {
@@ -337,23 +343,24 @@ const resetPasswordUpdates = asyncWrapper(async (req, res) => {
         at least one uppercase letter, one lowercase letter, one number, and one symbol`,
     });
   }
-  const currentUser = await userService.findUser(email);
 
-  const tokenStatus = await verificationTokenService.verifyToken(
-    currentUser._id,
+  const existingUser = await userService.findUser(email);
+  const token = await verificationTokenService.verifyToken(
+    existingUser._id,
     resetPasswordToken,
+    'password',
   );
-
-  if (!tokenStatus.valid) {
+  // Validate if token has been blacklisted or has expired
+  if (!token.valid) {
     return res
       .status(StatusCodes.UNAUTHORIZED)
-      .json({ msg: 'Token is invalid or has expired.' });
+      .json({ msg: 'Token has expired or is no longer valid.' });
   }
-
   const user = await userService.updateUserPassword(email, password);
   await user.save();
   await resetAttempts(user._id);
 
+  // Invalidate tokens after successful password update
   await verificationTokenService.invalidateTokens(user._id);
 
   return res

--- a/service/user-service.js
+++ b/service/user-service.js
@@ -56,7 +56,7 @@ const validateUserAndToken = async (email, token) => {
     user._id,
     token,
   );
-  return user && resetPasswordTokenVerified;
+  return resetPasswordTokenVerified;
 };
 
 const updateUserPassword = async (email, password) => {

--- a/service/user-service.js
+++ b/service/user-service.js
@@ -50,11 +50,12 @@ const activateAccount = async (email) => {
   return user;
 };
 
-const validateUserAndToken = async (email, token) => {
+const validateUserAndToken = async (email, token, tokenType) => {
   const user = await findUser(email);
   const resetPasswordTokenVerified = await verificationTokenService.verifyToken(
     user._id,
     token,
+    tokenType
   );
   return resetPasswordTokenVerified;
 };

--- a/utils/tokenUtils.js
+++ b/utils/tokenUtils.js
@@ -24,7 +24,7 @@ const createJWTEmail = (payload) => {
 };
 
 const createJWTPasswordReset = (payload) => {
-  const token = jwt.sign(payload, JWT_EMAIL_VERIFICATION_SECRET, {
+  const token = jwt.sign(payload, JWT_RESET_PASSWORD_SECRET, {
     expiresIn: JWT_LIFETIME,
   });
   return token;


### PR DESCRIPTION
Fix/45/password reset link lifetime

## One Line Description
Restricts resetPassword token to one time use and sets expiry to resetPassword token.

## Requirements
Users should only be able to use the password reset link once.

## Notes
JWT secret and lifetime needs to be added to .env file. This will be shared  separately.

## Test Steps
1. Click on login in homepage.
2. Click on 'Forgot your password?'
3. Enter the email address you use to log into application
4. Open the reset password link sent to your email
5. Input a new password and click Next. You should be brought to a confirmation  page.
6. Go back to the previous  page on your browser.
7. Open the network tab and try  to update your password again. You should receive an error - this will need to be handled correctly in the front end.

## Video demo
https://app.screencastify.com/v3/watch/HpmzMqlaYdakn2Aw3HTK