### PR TITLE
Feat/52/set up multer and cloudinary

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,10 +8,12 @@ const morgan = require('morgan');
 const helmet = require('helmet');
 // eslint-disable-next-line import/no-extraneous-dependencies
 // const mongoSanitize = require('express-mongo-sanitize');
+const { cloudinaryConfig } = require('./config/cloudinary-config');
 
 const kidsRoutes = require('./routes/kids');
 const userRoutes = require('./routes/user');
 const shareKid = require('./routes/share-kid');
+const albumRoutes = require('./routes/album');
 
 const errorHandlerMiddleware = require('./middleware/error-handler');
 const notFoundMiddleware = require('./middleware/not-found');
@@ -44,12 +46,14 @@ app.use(express.urlencoded({ extended: false }));
 app.use(morgan('dev'));
 app.use(morgan(':body'));
 app.use(cookieParser(process.env.JWT_SECRET)); //the secret key should match the one we sign the cookie with
+app.use('*', cloudinaryConfig);
 
 // Routes
 app.use('/api/v1', userRoutes);
 app.use('/api/v1', shareKid);
 app.use('/api/v1/kids', kidsRoutes);
 app.use('/api/v1/kids', shareKid);
+app.use('/api/v1', albumRoutes);
 
 // Error handling middleware
 app.use(notFoundMiddleware);

--- a/config/cloudinary-config.js
+++ b/config/cloudinary-config.js
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { config, uploader } = require('cloudinary').v2;
+
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const cloudinaryConfig = (req, res, next) => {
+  config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+  });
+  next();
+};
+
+module.exports = { cloudinaryConfig, uploader };

--- a/controllers/album-controller.js
+++ b/controllers/album-controller.js
@@ -1,0 +1,20 @@
+const { StatusCodes } = require('http-status-codes');
+const asyncWrapper = require('../middleware/async-wrapper');
+const { uploadFilesCloudinary } = require('../service/album-service');
+
+const { dataUri } = require('../middleware/multer');
+
+// Route to upload files through multer and cloudinary
+const fileUploader = asyncWrapper(async (req, res) => {
+  const uploadPromises = req.files.map(async (file) => {
+    const fileUri = dataUri(file).content;
+    const uploadResult = await uploadFilesCloudinary(fileUri);
+    return uploadResult;
+  });
+
+  const uploadResults = await Promise.all(uploadPromises);
+
+  res.status(StatusCodes.MULTI_STATUS).json(uploadResults);
+});
+
+module.exports = { fileUploader };

--- a/controllers/album-controller.js
+++ b/controllers/album-controller.js
@@ -6,9 +6,10 @@ const { dataUri } = require('../middleware/multer');
 
 // Route to upload files through multer and cloudinary
 const fileUploader = asyncWrapper(async (req, res) => {
+  const { userId } = req.params;
   const uploadPromises = req.files.map(async (file) => {
     const fileUri = dataUri(file).content;
-    const uploadResult = await uploadFilesCloudinary(fileUri);
+    const uploadResult = await uploadFilesCloudinary(fileUri, userId);
     return uploadResult;
   });
 

--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -1,0 +1,47 @@
+const multer = require('multer');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const DatauriParser = require('datauri/parser');
+
+// Image is stored in memory prior to being streamed to cloudinary as there may be restrictions in temporarily storing in the server's harddisk.
+const storage = multer.memoryStorage();
+const uploadFilter = (req, file, cb) => {
+  const typeArray = file.mimetype.split('/');
+  const fileType = typeArray[1];
+  if (
+    fileType === 'jpg' ||
+    fileType === 'png' ||
+    fileType === 'jpeg' ||
+    fileType === 'pdf'
+  ) {
+    cb(null, true);
+  } else {
+    cb('File type is not accepted', false);
+  }
+};
+const fileNameFormater = (req, file, callback) => {
+  callback(null, `${file.fieldname}_${Date.now()}'`);
+};
+
+// Multer configurations
+const upload = multer({
+  storage: storage,
+  fileFilter: uploadFilter,
+  filename: fileNameFormater,
+});
+
+// Multer uploader
+const multerUploader = upload.array('image', 5);
+
+/**
+ * @description This function converts the buffer to data url
+ * @param {Object} file containing the field object
+ * @returns {String} The data url from the string buffer
+ */
+const parser = new DatauriParser();
+const dataUri = (file) =>
+  parser.format(file.mimetype.split('/')[1], file.buffer);
+
+module.exports = {
+  multerUploader,
+  dataUri,
+};

--- a/routes/album.js
+++ b/routes/album.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const router = express.Router();
+const { fileUploader } = require('../controllers/album-controller');
+const { multerUploader } = require('../middleware/multer');
+
+router.post('/uploadFiles', multerUploader, fileUploader);
+
+module.exports = router;

--- a/routes/album.js
+++ b/routes/album.js
@@ -4,6 +4,6 @@ const router = express.Router();
 const { fileUploader } = require('../controllers/album-controller');
 const { multerUploader } = require('../middleware/multer');
 
-router.post('/uploadFiles', multerUploader, fileUploader);
+router.post('/uploadFiles/:userId', multerUploader, fileUploader);
 
 module.exports = router;

--- a/service/album-service.js
+++ b/service/album-service.js
@@ -1,22 +1,21 @@
+const { StatusCodes } = require('http-status-codes');
 const { uploader } = require('../config/cloudinary-config');
 
-// Express route for file upload
-const uploadFilesCloudinary = async (file) => {
+// Upload files to Cloudinary
+const uploadFilesCloudinary = async (file, userId) => {
   try {
-    // Upload file to Cloudinary
     const result = await uploader.upload(file, {
-      folder: 'album',
+      folder: `album/${userId}`,
     });
 
-    // Send the Cloudinary URL in the response
     return {
-      status: 200,
+      status: StatusCodes.OK,
       message: 'File successfully uploaded to Cloudinary',
       url: result.secure_url,
     };
   } catch (error) {
     return {
-      status: 500,
+      status: StatusCodes.BAD_GATEWAY,
       message: 'Error uploading file to Cloudinary',
       error: error,
     };

--- a/service/album-service.js
+++ b/service/album-service.js
@@ -1,0 +1,28 @@
+const { uploader } = require('../config/cloudinary-config');
+
+// Express route for file upload
+const uploadFilesCloudinary = async (file) => {
+  try {
+    // Upload file to Cloudinary
+    const result = await uploader.upload(file, {
+      folder: 'album',
+    });
+
+    // Send the Cloudinary URL in the response
+    return {
+      status: 200,
+      message: 'File successfully uploaded to Cloudinary',
+      url: result.secure_url,
+    };
+  } catch (error) {
+    return {
+      status: 500,
+      message: 'Error uploading file to Cloudinary',
+      error: error,
+    };
+  }
+};
+
+module.exports = {
+  uploadFilesCloudinary,
+};


### PR DESCRIPTION
## One Line Description
 Set up multer and cloudinary in backend 

## Requirements
 Set up multer and cloudinary in backend to handle uploading images and pdf files shared through messaging app to album service. 

## Notes
Messaging app and album service has not been built so integration is out of scope. PR is only to setup multer and cloudinary services. Integration will be done separately once requirements for messaging service and album service is provided.

## Test Steps
Can only be tested with postman.

## Testing Instructions for Postman
Setup request as follows. Endpoint should be in the following  format: http://localhost:8000/api/v1/uploadFiles/<userID>

![image](https://github.com/user-attachments/assets/8f38454e-016c-45db-a5de-4a2df8a19f80)