### PR TITLE
Fix: Create Kid service does not add dateOfBirth

### DIFF
--- a/models/Kid.js
+++ b/models/Kid.js
@@ -35,12 +35,17 @@ const KidsSchema = new Schema(
     imageProfilePublicId: {
       type: String,
     },
-    DOB: {
+    dateOfBirthday: {
       type: String,
       validate: {
         validator: validateDOB,
         message: 'The date needs to be in the past',
+        required: true,
       },
+    },
+    age: {
+      type: String,
+      required: [true, 'Age is a required field'],
     },
     allergies: {
       type: [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "helmet": "^7.1.0",
     "http-status-codes": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
+    "moment": "^2.30.1",
     "mongoose": "^6.7.2",
     "mongoose-unique-validator": "^3.1.0",
     "morgan": "^1.10.0",

--- a/service/kid-service.js
+++ b/service/kid-service.js
@@ -1,5 +1,7 @@
+const moment = require('moment');
 const Kid = require('../models/Kid');
 const User = require('../models/User');
+const { dateConverter } = require('../utils/helper');
 
 const getAllKids = async (userId) => {
   const allKids = Kid.find({ custodyIDs: userId });
@@ -10,7 +12,8 @@ const getAllKids = async (userId) => {
 };
 
 const createKid = async (data, userId) => {
-  const kid = new Kid({ ...data, custodyIDs: [userId] });
+  const age = moment().diff(dateConverter(data.dateOfBirthday), 'years', false);
+  const kid = new Kid({ ...data, age: age, custodyIDs: [userId] });
   await kid.save();
   await User.findByIdAndUpdate(userId, { $push: { kids: kid._id } });
   return kid;

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -1,0 +1,9 @@
+const dateConverter = (value) => {
+  const [month, day, year] = value.split('/');
+  const date = new Date(`${year}-${month}-${day}`);
+  return date;
+};
+
+module.exports = {
+  dateConverter,
+};

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -1,3 +1,5 @@
+const { dateConverter } = require('./helper');
+
 const validateImageURL = (url) => /\.(jpeg|jpg|png)$/.test(url);
 
 const validateImageSize = () => {
@@ -9,8 +11,7 @@ const validateImageSize = () => {
 
 const validateDOB = (value) => {
   if (!value) return true;
-  const [day, month, year] = value.split('/');
-  const date = new Date(`${year}-${month}-${day}`);
+  const date = dateConverter(value);
   return date < new Date();
 };
 


### PR DESCRIPTION
## One Line Description
CreateKid service does not add dateOfBirthday or age field

## Requirements
-  dateOfBirth field should be mandatory in the backend

## Notes
This PR is to accompany changes to the frontend here: https://github.com/JULIERAJ/KIDS-FIRST-Front/pull/111

## Testing Instructions for Postman
- Detailed steps on how to test the changes using Postman.
- Include specific endpoints to be tested, required headers, request bodies, and expected responses.
- Refer to the example in the contributing file for details.

## API Changes (if there are any)
- CreateKid endpoint has been updated to calculate age of child. This uses the moment.js library.

## Database Changes (if there are any)
- DOB field in Kids Model has been updated to "dateOfBirthday" field.

## Checklist
- [x] Pull Request title includes the issue number and a brief description of the change.
- [x] All changes should be tested and verified to work correctly.
- [x] Code follows backend best practices.
- [x] Branch names follow the conventions in the contributing file.
- [x] Commit messages follow the naming conventions in the contributing file.
- [x] No sensitive data or secrets are included in the codebase.