### PR TITLE
Add multer and cloudinary to CreateKid service

### DIFF
--- a/controllers/album-controller.js
+++ b/controllers/album-controller.js
@@ -1,7 +1,7 @@
 const { StatusCodes } = require('http-status-codes');
 const asyncWrapper = require('../middleware/async-wrapper');
+const { uploadFilesCloudinary } = require('../middleware/cloudinary');
 const {
-  uploadFilesCloudinary,
   createNewAlbum,
   getAlbum,
   updateAlbum,

--- a/controllers/kids-controller.js
+++ b/controllers/kids-controller.js
@@ -20,8 +20,8 @@ const createKidCtrl = asyncWrapper(async (req, res) => {
   try {
     const { id: userId } = req.user;
     let imageProfileURL;
-    if (req.files) {
-      const fileUri = dataUri(req.files[0]).content;
+    if (req.file) {
+      const fileUri = dataUri(req.file).content;
       const cloudinaryUploadResult = await uploadFilesCloudinary(
         fileUri,
         userId,

--- a/controllers/kids-controller.js
+++ b/controllers/kids-controller.js
@@ -7,6 +7,8 @@ const {
   updateKid,
   deleteKid,
 } = require('../service/kid-service');
+const { uploadFilesCloudinary } = require('../middleware/cloudinary');
+const { dataUri } = require('../middleware/multer');
 
 const getAllKidsCtrl = asyncWrapper(async (req, res) => {
   const { id: userId } = req.user;
@@ -15,9 +17,26 @@ const getAllKidsCtrl = asyncWrapper(async (req, res) => {
 });
 
 const createKidCtrl = asyncWrapper(async (req, res) => {
-  const { id: userId } = req.user;
-  const newKid = await createKid(req.body, userId);
-  res.status(StatusCodes.CREATED).json({ newKid });
+  try {
+    const { id: userId } = req.user;
+    let imageProfileURL;
+    if (req.files) {
+      const fileUri = dataUri(req.files[0]).content;
+      const cloudinaryUploadResult = await uploadFilesCloudinary(
+        fileUri,
+        userId,
+      );
+      imageProfileURL = cloudinaryUploadResult.url;
+    }
+
+    const newKid = await createKid(req.body, userId, imageProfileURL);
+
+    res.status(StatusCodes.CREATED).json({ newKid });
+  } catch (err) {
+    res.status(StatusCodes.BAD_GATEWAY).json({
+      err,
+    });
+  }
 });
 
 const getKidByIdCtrl = asyncWrapper(async (req, res) => {

--- a/middleware/cloudinary.js
+++ b/middleware/cloudinary.js
@@ -1,0 +1,25 @@
+const { StatusCodes } = require('http-status-codes');
+const { uploader } = require('../config/cloudinary-config');
+
+// Upload files to Cloudinary
+const uploadFilesCloudinary = async (file, userId) => {
+  try {
+    const result = await uploader.upload(file, {
+      folder: `albums/${userId}`,
+    });
+
+    return {
+      status: StatusCodes.OK,
+      message: 'File successfully uploaded to Cloudinary.',
+      url: result.secure_url,
+    };
+  } catch (error) {
+    return {
+      status: StatusCodes.BAD_GATEWAY,
+      message: 'Error uploading file to Cloudinary.',
+      error: error,
+    };
+  }
+};
+
+module.exports = { uploadFilesCloudinary };

--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -11,12 +11,7 @@ const fileUploadFilter = (req, file, callback) => {
   const typeArray = file.mimetype.split('/');
   const fileType = typeArray[1];
   try {
-    if (
-      fileType === 'jpg' ||
-      fileType === 'png' ||
-      fileType === 'jpeg' ||
-      fileType === 'pdf'
-    ) {
+    if (fileType === 'jpg' || fileType === 'png' || fileType === 'jpeg') {
       callback(null, true);
     } else {
       callback(new multer.MulterError('UNACCEPTED_FILE_TYPE'), false);
@@ -50,7 +45,28 @@ const multerUploader = (req, res, next) => {
       if (err.code === 'LIMIT_FILE_SIZE') {
         err.message = `File or files are too large. File size must be limited to ${fileSize} bytes.`;
       } else if (err.code === 'UNACCEPTED_FILE_TYPE') {
-        err.message = `File with unaccepted file type sent. Accepted file types are : .jpg || .png || .jpeg || .pdf`;
+        err.message = `File with unaccepted file type sent. Accepted file types are : .jpg || .png || .jpeg`;
+        err.name = 'fileFilterError';
+        err.field = 'file';
+      }
+      res.status(StatusCodes.BAD_REQUEST).json({ error: err });
+    } else if (err) {
+      res.status(StatusCodes.BAD_GATEWAY).json({ error: err });
+    } else {
+      next();
+    }
+  });
+};
+
+const multerKidsPhotoUploader = (req, res, next) => {
+  const uploadFiletoMulter = upload.single('imageProfileURL');
+
+  uploadFiletoMulter(req, res, (err) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        err.message = `File or files are too large. File size must be limited to ${fileSize} bytes.`;
+      } else if (err.code === 'UNACCEPTED_FILE_TYPE') {
+        err.message = `File with unaccepted file type sent. Accepted file types are : .jpg || .png || .jpeg`;
         err.name = 'fileFilterError';
         err.field = 'file';
       }
@@ -71,8 +87,8 @@ const multerUploader = (req, res, next) => {
 const parser = new DatauriParser();
 const dataUri = (file) =>
   parser.format(file.mimetype.split('/')[1], file.buffer);
-
 module.exports = {
   multerUploader,
+  multerKidsPhotoUploader,
   dataUri,
 };

--- a/routes/kids.js
+++ b/routes/kids.js
@@ -3,9 +3,17 @@ const express = require('express');
 const router = express.Router();
 const kidsController = require('../controllers/kids-controller');
 const authenticateUser = require('../middleware/authentication');
+const { multerKidsPhotoUploader } = require('../middleware/multer');
+const { cloudinaryConfig } = require('../config/cloudinary-config');
 
 router.get('/', authenticateUser, kidsController.getAllKids);
-router.post('/', authenticateUser, kidsController.createKid);
+router.post(
+  '/',
+  authenticateUser,
+  multerKidsPhotoUploader,
+  cloudinaryConfig,
+  kidsController.createKid,
+);
 router.get('/:id', authenticateUser, kidsController.getKidById);
 router.put('/:id', authenticateUser, kidsController.updateKid);
 router.delete('/:id', authenticateUser, kidsController.deleteKid);

--- a/service/album-service.js
+++ b/service/album-service.js
@@ -1,31 +1,7 @@
 /* eslint-disable camelcase */
 const { StatusCodes } = require('http-status-codes');
-const {
-  uploader,
-  resources_by_asset_folder,
-} = require('../config/cloudinary-config');
+const { resources_by_asset_folder } = require('../config/cloudinary-config');
 const Album = require('../models/Album');
-
-// Upload files to Cloudinary
-const uploadFilesCloudinary = async (file, userId) => {
-  try {
-    const result = await uploader.upload(file, {
-      folder: `albums/${userId}`,
-    });
-
-    return {
-      status: StatusCodes.OK,
-      message: 'File successfully uploaded to Cloudinary.',
-      url: result.secure_url,
-    };
-  } catch (error) {
-    return {
-      status: StatusCodes.BAD_GATEWAY,
-      message: 'Error uploading file to Cloudinary.',
-      error: error,
-    };
-  }
-};
 
 // Create new album in database
 const createNewAlbum = async (data) => {
@@ -106,7 +82,6 @@ const getAllPhotoCloudinary = async (userId) => {
 };
 
 module.exports = {
-  uploadFilesCloudinary,
   createNewAlbum,
   getAlbum,
   updateAlbum,

--- a/service/kid-service.js
+++ b/service/kid-service.js
@@ -11,12 +11,37 @@ const getAllKids = async (userId) => {
   return allKids;
 };
 
-const createKid = async (data, userId) => {
-  const age = moment().diff(dateConverter(data.dateOfBirthday), 'years', false);
-  const kid = new Kid({ ...data, age: age, custodyIDs: [userId] });
-  await kid.save();
-  await User.findByIdAndUpdate(userId, { $push: { kids: kid._id } });
-  return kid;
+const createKid = async (data, userId, imageProfileURL) => {
+  try {
+    let kid;
+    const age = moment().diff(
+      dateConverter(data.dateOfBirthday),
+      'years',
+      false,
+    );
+    if (data.allergies.length === 0) data.allergies = [];
+    if (data.interests.length === 0) data.interests = [];
+    if (data.fears.length === 0) data.fears = [];
+    if (imageProfileURL) {
+      kid = new Kid({
+        ...data,
+        age: age,
+        custodyIDs: [userId],
+        imageProfileURL: imageProfileURL,
+      });
+    } else {
+      kid = new Kid({
+        ...data,
+        age: age,
+        custodyIDs: [userId],
+      });
+    }
+    await kid.save();
+    await User.findByIdAndUpdate(userId, { $push: { kids: kid._id } });
+    return kid;
+  } catch (err) {
+    throw new Error(err);
+  }
 };
 
 const getKidById = async (kidId, userId) => {


### PR DESCRIPTION
## One Line Description
Add multer and cloudinary to CreateKid service

## Requirements
Uploading kid's photo to backend without formData type is complicated. Backend needed to be updated to use multer to handle file upload. Additionally, a file storage system needed to be added to store the images. For this, cloudinary needed to be added to the service.

## Notes
This will help block Alaleh's work on the Upload Kid's Photo work.

## Testing Instructions for Postman
- In Postman, setup a POST request to http://localhost:8000/api/v1/kids. 
- Add the following fields to the header ( you can get the token from the frontend DevTools ): 
![image](https://github.com/user-attachments/assets/c05fd274-59ac-4355-8dfc-6dcc2057acbb)
- Add the following fields to the body and send request:
![image](https://github.com/user-attachments/assets/6e1cf6a1-0cf4-4183-9030-44bf44ea300e)

## API Changes (if there are any)
- createKidCtrl is now setup to use multer and cloudinary

## UI/UX changes
I've tested this with local frontend changes to confirm that we will be able to update the frontend as well :
![image](https://github.com/user-attachments/assets/eaee1126-00f0-4069-875c-083224927b0d)

## Checklist
- [x] Pull Request title includes the issue number and a brief description of the change.
- [x] All changes should be tested and verified to work correctly.
- [x] Code follows backend best practices.
- [x] Branch names follow the conventions in the contributing file.
- [x] Commit messages follow the naming conventions in the contributing file.
- [x] No sensitive data or secrets are included in the codebase.